### PR TITLE
feat: extra registration fields improvements

### DIFF
--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -75,6 +75,7 @@ const FormFieldRenderer = (props) => {
             name={fieldData.name}
             value={value}
             placeholder={fieldData.placeholder}
+            maxLength={fieldData.restrictions?.max_length}
             aria-invalid={isRequired && Boolean(errorMessage)}
             onChange={(e) => onChangeHandler(e)}
             floatingLabel={fieldData.label}
@@ -95,6 +96,7 @@ const FormFieldRenderer = (props) => {
             name={fieldData.name}
             value={value}
             placeholder={fieldData.placeholder}
+            maxLength={fieldData.restrictions?.max_length}
             aria-invalid={isRequired && Boolean(errorMessage)}
             onChange={(e) => onChangeHandler(e)}
             floatingLabel={fieldData.label}
@@ -151,6 +153,10 @@ FormFieldRenderer.propTypes = {
     name: PropTypes.string,
     placeholder: PropTypes.string,
     instructions: PropTypes.string,
+    restrictions: PropTypes.shape({
+      max_length: PropTypes.number,
+      min_length: PropTypes.number,
+    }),
     options: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
   }).isRequired,
   onChangeHandler: PropTypes.func.isRequired,

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -42,6 +42,10 @@ const FormFieldRenderer = (props) => {
       if (!fieldData.options) {
         return null;
       }
+      const optionsArray = Array.isArray(fieldData.options)
+        ? fieldData.options
+        : Object.entries(fieldData.options);
+
       formField = (
         <Form.Group controlId={fieldData.name} isInvalid={!!(isRequired && errorMessage)}>
           <Form.Control
@@ -56,14 +60,14 @@ const FormFieldRenderer = (props) => {
             onBlur={handleOnBlur}
             onFocus={handleFocus}
           >
-          <option key="default" value="">{fieldData.label}</option>
-          {fieldData.options.map(option => (
-            <option className="data-hj-suppress" key={option[0]} value={option[0]}>{option[1]}</option>
-          ))}
-        </Form.Control>
-        {helpTextFeedback}
-        {errorFeedback}
-      </Form.Group>
+            <option key="default" value="">{fieldData.label}</option>
+            {optionsArray.map(option => (
+              <option className="data-hj-suppress" key={option[0]} value={option[0]}>{option[1]}</option>
+            ))}
+          </Form.Control>
+          {helpTextFeedback}
+          {errorFeedback}
+        </Form.Group>
       );
       break;
     }
@@ -113,22 +117,22 @@ const FormFieldRenderer = (props) => {
     case 'checkbox': {
       formField = (
         <Form.Group isInvalid={!!(isRequired && errorMessage)}>
-        <Form.Checkbox
-          className={className}
-          id={fieldData.name}
-          checked={!!value}
-          name={fieldData.name}
-          value={value}
-          aria-invalid={isRequired && Boolean(errorMessage)}
-          onChange={(e) => onChangeHandler(e)}
-          onBlur={handleOnBlur}
-          onFocus={handleFocus}
-        >
-          {fieldData.label}
-        </Form.Checkbox>
-        {helpTextFeedback}
-        {errorFeedback}
-      </Form.Group>
+          <Form.Checkbox
+            className={className}
+            id={fieldData.name}
+            checked={!!value}
+            name={fieldData.name}
+            value={value}
+            aria-invalid={isRequired && Boolean(errorMessage)}
+            onChange={(e) => onChangeHandler(e)}
+            onBlur={handleOnBlur}
+            onFocus={handleFocus}
+          >
+            {fieldData.label}
+          </Form.Checkbox>
+          {helpTextFeedback}
+          {errorFeedback}
+        </Form.Group>
       );
       break;
     }
@@ -159,7 +163,10 @@ FormFieldRenderer.propTypes = {
       max_length: PropTypes.number,
       min_length: PropTypes.number,
     }),
-    options: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+    options: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+      PropTypes.objectOf(PropTypes.string),
+    ]),
   }).isRequired,
   onChangeHandler: PropTypes.func.isRequired,
   handleBlur: PropTypes.func,

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -56,13 +56,14 @@ const FormFieldRenderer = (props) => {
             onBlur={handleOnBlur}
             onFocus={handleFocus}
           >
-            <option key="default" value="">{fieldData.label}</option>
-            {fieldData.options.map(option => (
-              <option className="data-hj-suppress" key={option[0]} value={option[0]}>{option[1]}</option>
-            ))}
-          </Form.Control>
-          {errorFeedback}
-        </Form.Group>
+          <option key="default" value="">{fieldData.label}</option>
+          {fieldData.options.map(option => (
+            <option className="data-hj-suppress" key={option[0]} value={option[0]}>{option[1]}</option>
+          ))}
+        </Form.Control>
+        {helpTextFeedback}
+        {errorFeedback}
+      </Form.Group>
       );
       break;
     }
@@ -112,21 +113,22 @@ const FormFieldRenderer = (props) => {
     case 'checkbox': {
       formField = (
         <Form.Group isInvalid={!!(isRequired && errorMessage)}>
-          <Form.Checkbox
-            className={className}
-            id={fieldData.name}
-            checked={!!value}
-            name={fieldData.name}
-            value={value}
-            aria-invalid={isRequired && Boolean(errorMessage)}
-            onChange={(e) => onChangeHandler(e)}
-            onBlur={handleOnBlur}
-            onFocus={handleFocus}
-          >
-            {fieldData.label}
-          </Form.Checkbox>
-          {errorFeedback}
-        </Form.Group>
+        <Form.Checkbox
+          className={className}
+          id={fieldData.name}
+          checked={!!value}
+          name={fieldData.name}
+          value={value}
+          aria-invalid={isRequired && Boolean(errorMessage)}
+          onChange={(e) => onChangeHandler(e)}
+          onBlur={handleOnBlur}
+          onFocus={handleFocus}
+        >
+          {fieldData.label}
+        </Form.Checkbox>
+        {helpTextFeedback}
+        {errorFeedback}
+      </Form.Group>
       );
       break;
     }

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -80,6 +80,7 @@ const FormFieldRenderer = (props) => {
             name={fieldData.name}
             value={value}
             placeholder={fieldData.placeholder}
+            minLength={fieldData.restrictions?.min_length}
             maxLength={fieldData.restrictions?.max_length}
             aria-invalid={isRequired && Boolean(errorMessage)}
             onChange={(e) => onChangeHandler(e)}
@@ -101,6 +102,7 @@ const FormFieldRenderer = (props) => {
             name={fieldData.name}
             value={value}
             placeholder={fieldData.placeholder}
+            minLength={fieldData.restrictions?.min_length}
             maxLength={fieldData.restrictions?.max_length}
             aria-invalid={isRequired && Boolean(errorMessage)}
             onChange={(e) => onChangeHandler(e)}
@@ -160,6 +162,7 @@ FormFieldRenderer.propTypes = {
     placeholder: PropTypes.string,
     instructions: PropTypes.string,
     restrictions: PropTypes.shape({
+      min_length: PropTypes.number,
       max_length: PropTypes.number,
     }),
     options: PropTypes.oneOfType([

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -1,22 +1,41 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Form, Icon } from '@openedx/paragon';
+import { Form, Icon, TransitionReplace } from '@openedx/paragon';
 import { ExpandMore } from '@openedx/paragon/icons';
 import PropTypes from 'prop-types';
 
 const FormFieldRenderer = (props) => {
+  const [hasFocus, setHasFocus] = useState(false);
   let formField = null;
   const {
     className, errorMessage, fieldData, onChangeHandler, isRequired, value,
   } = props;
 
   const handleFocus = (e) => {
+    setHasFocus(true);
     if (props.handleFocus) { props.handleFocus(e); }
   };
 
   const handleOnBlur = (e) => {
+    setHasFocus(false);
     if (props.handleBlur) { props.handleBlur(e); }
   };
+
+  const helpTextFeedback = (
+    <TransitionReplace>
+      {hasFocus && fieldData.instructions ? (
+        <Form.Control.Feedback type="default" key="help-text" className="d-block form-text-size">
+          {fieldData.instructions}
+        </Form.Control.Feedback>
+      ) : <div key="empty" />}
+    </TransitionReplace>
+  );
+
+  const errorFeedback = isRequired && errorMessage ? (
+    <Form.Control.Feedback id={`${fieldData.name}-error`} type="invalid" className="form-text-size" hasIcon={false}>
+      {errorMessage}
+    </Form.Control.Feedback>
+  ) : null;
 
   switch (fieldData.type) {
     case 'select': {
@@ -42,11 +61,7 @@ const FormFieldRenderer = (props) => {
               <option className="data-hj-suppress" key={option[0]} value={option[0]}>{option[1]}</option>
             ))}
           </Form.Control>
-          {isRequired && errorMessage && (
-            <Form.Control.Feedback id={`${fieldData.name}-error`} type="invalid" className="form-text-size" hasIcon={false}>
-              {errorMessage}
-            </Form.Control.Feedback>
-          )}
+          {errorFeedback}
         </Form.Group>
       );
       break;
@@ -66,11 +81,8 @@ const FormFieldRenderer = (props) => {
             onBlur={handleOnBlur}
             onFocus={handleFocus}
           />
-          {isRequired && errorMessage && (
-            <Form.Control.Feedback id={`${fieldData.name}-error`} type="invalid" className="form-text-size" hasIcon={false}>
-              {errorMessage}
-            </Form.Control.Feedback>
-          )}
+          {helpTextFeedback}
+          {errorFeedback}
         </Form.Group>
       );
       break;
@@ -89,11 +101,8 @@ const FormFieldRenderer = (props) => {
             onBlur={handleOnBlur}
             onFocus={handleFocus}
           />
-          {isRequired && errorMessage && (
-            <Form.Control.Feedback id={`${fieldData.name}-error`} type="invalid" className="form-text-size" hasIcon={false}>
-              {errorMessage}
-            </Form.Control.Feedback>
-          )}
+          {helpTextFeedback}
+          {errorFeedback}
         </Form.Group>
       );
       break;
@@ -114,11 +123,7 @@ const FormFieldRenderer = (props) => {
           >
             {fieldData.label}
           </Form.Checkbox>
-          {isRequired && errorMessage && (
-            <Form.Control.Feedback id={`${fieldData.name}-error`} type="invalid" className="form-text-size" hasIcon={false}>
-              {errorMessage}
-            </Form.Control.Feedback>
-          )}
+          {errorFeedback}
         </Form.Group>
       );
       break;
@@ -145,6 +150,7 @@ FormFieldRenderer.propTypes = {
     label: PropTypes.string,
     name: PropTypes.string,
     placeholder: PropTypes.string,
+    instructions: PropTypes.string,
     options: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
   }).isRequired,
   onChangeHandler: PropTypes.func.isRequired,

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -27,7 +27,7 @@ const FormFieldRenderer = (props) => {
         <Form.Control.Feedback type="default" key="help-text" className="d-block form-text-size">
           {fieldData.instructions}
         </Form.Control.Feedback>
-      ) : <div key="empty" />}
+      ) : <React.Fragment key="empty" />}
     </TransitionReplace>
   );
 
@@ -161,7 +161,6 @@ FormFieldRenderer.propTypes = {
     instructions: PropTypes.string,
     restrictions: PropTypes.shape({
       max_length: PropTypes.number,
-      min_length: PropTypes.number,
     }),
     options: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),

--- a/src/field-renderer/FieldRenderer.jsx
+++ b/src/field-renderer/FieldRenderer.jsx
@@ -59,6 +59,7 @@ const FormFieldRenderer = (props) => {
             as="textarea"
             name={fieldData.name}
             value={value}
+            placeholder={fieldData.placeholder}
             aria-invalid={isRequired && Boolean(errorMessage)}
             onChange={(e) => onChangeHandler(e)}
             floatingLabel={fieldData.label}
@@ -81,6 +82,7 @@ const FormFieldRenderer = (props) => {
             className={className}
             name={fieldData.name}
             value={value}
+            placeholder={fieldData.placeholder}
             aria-invalid={isRequired && Boolean(errorMessage)}
             onChange={(e) => onChangeHandler(e)}
             floatingLabel={fieldData.label}
@@ -142,6 +144,7 @@ FormFieldRenderer.propTypes = {
     type: PropTypes.string,
     label: PropTypes.string,
     name: PropTypes.string,
+    placeholder: PropTypes.string,
     options: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
   }).isRequired,
   onChangeHandler: PropTypes.func.isRequired,

--- a/src/field-renderer/tests/FieldRenderer.test.jsx
+++ b/src/field-renderer/tests/FieldRenderer.test.jsx
@@ -350,4 +350,135 @@ describe('FieldRendererTests', () => {
     // Note: Select fields don't show help text in the current implementation
     // This test documents the current behavior
   });
+
+  it('should render select field with options as object format', () => {
+    const fieldData = {
+      type: 'select',
+      label: 'Favorite Language',
+      name: 'favorite-language-field',
+      options: {
+        '': '---------',
+        python: 'Python',
+        javascript: 'JavaScript',
+        java: 'Java',
+        go: 'Go',
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const select = container.querySelector('select#favorite-language-field');
+    const label = container.querySelector('label');
+
+    expect(select.type).toEqual('select-one');
+    expect(label.textContent).toContain(fieldData.label);
+
+    // Verify all options are rendered
+    const options = select.querySelectorAll('option');
+    expect(options.length).toBeGreaterThan(0);
+
+    // Check if specific options exist
+    const pythonOption = Array.from(options).find((opt) => opt.value === 'python');
+    expect(pythonOption).toBeTruthy();
+    expect(pythonOption.textContent).toEqual('Python');
+
+    const javascriptOption = Array.from(options).find((opt) => opt.value === 'javascript');
+    expect(javascriptOption).toBeTruthy();
+    expect(javascriptOption.textContent).toEqual('JavaScript');
+  });
+
+  it('should handle selection change with object format options', () => {
+    const fieldData = {
+      type: 'select',
+      label: 'Favorite Language',
+      name: 'favorite-language-field',
+      options: {
+        '': '---------',
+        python: 'Python',
+        javascript: 'JavaScript',
+        java: 'Java',
+        go: 'Go',
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const select = container.querySelector('select#favorite-language-field');
+
+    fireEvent.change(select, { target: { value: 'python' } });
+    expect(value).toEqual('python');
+
+    fireEvent.change(select, { target: { value: 'javascript' } });
+    expect(value).toEqual('javascript');
+  });
+
+  it('should render all options correctly from object format', () => {
+    const fieldData = {
+      type: 'select',
+      label: 'Programming Language',
+      name: 'language-field',
+      options: {
+        '': '---------',
+        python: 'Python',
+        javascript: 'JavaScript',
+        java: 'Java',
+        go: 'Go',
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const select = container.querySelector('select#language-field');
+    const options = select.querySelectorAll('option');
+
+    // Should have default option + 5 from object (including empty string)
+    const optionValues = Array.from(options).map((opt) => opt.value);
+    const optionLabels = Array.from(options).map((opt) => opt.textContent);
+
+    // Check that all expected values are present
+    expect(optionValues).toContain('python');
+    expect(optionValues).toContain('javascript');
+    expect(optionValues).toContain('java');
+    expect(optionValues).toContain('go');
+
+    // Check that all expected labels are present
+    expect(optionLabels).toContain('Python');
+    expect(optionLabels).toContain('JavaScript');
+    expect(optionLabels).toContain('Java');
+    expect(optionLabels).toContain('Go');
+  });
+
+  it('should handle select field with array format options (backwards compatibility)', () => {
+    const fieldData = {
+      type: 'select',
+      label: 'Year',
+      name: 'year-field',
+      options: [
+        ['2020', '2020'],
+        ['2021', '2021'],
+        ['2022', '2022'],
+      ],
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const select = container.querySelector('select#year-field');
+
+    fireEvent.change(select, { target: { value: '2021' } });
+    expect(value).toEqual('2021');
+
+    // Verify options are rendered correctly
+    const options = select.querySelectorAll('option');
+    const yearOption = Array.from(options).find((opt) => opt.value === '2021');
+    expect(yearOption).toBeTruthy();
+    expect(yearOption.textContent).toEqual('2021');
+  });
+
+  it('should return null if options is not an array or object', () => {
+    const fieldData = {
+      type: 'select',
+      label: 'Invalid Options',
+      name: 'invalid-field',
+      options: null,
+    };
+
+    const { container } = render(<FieldRenderer fieldData={fieldData} onChangeHandler={() => {}} />);
+    expect(container.innerHTML).toEqual('');
+  });
 });

--- a/src/field-renderer/tests/FieldRenderer.test.jsx
+++ b/src/field-renderer/tests/FieldRenderer.test.jsx
@@ -200,4 +200,152 @@ describe('FieldRendererTests', () => {
 
     expect(container.querySelector(`#${fieldData.name}-error`).textContent).toEqual('You must agree to our Honor Code');
   });
+
+  it('should render placeholder for text field', () => {
+    const fieldData = {
+      type: 'text',
+      label: 'Company',
+      name: 'company-field',
+      placeholder: 'Enter your company name',
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('input#company-field');
+
+    expect(input.placeholder).toEqual('Enter your company name');
+  });
+
+  it('should render placeholder for textarea field', () => {
+    const fieldData = {
+      type: 'textarea',
+      label: 'Goals',
+      name: 'goals-field',
+      placeholder: 'Share your learning goals',
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('#goals-field');
+
+    expect(input.placeholder).toEqual('Share your learning goals');
+  });
+
+  it('should apply maxLength restriction to text field', () => {
+    const fieldData = {
+      type: 'text',
+      label: 'Company',
+      name: 'company-field',
+      restrictions: {
+        max_length: 50,
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('input#company-field');
+
+    expect(input.maxLength).toEqual(50);
+  });
+
+  it('should apply maxLength restriction to textarea field', () => {
+    const fieldData = {
+      type: 'textarea',
+      label: 'Goals',
+      name: 'goals-field',
+      restrictions: {
+        max_length: 200,
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('#goals-field');
+
+    expect(input.maxLength).toEqual(200);
+  });
+
+  it('should show help text when field has focus and instructions are provided', () => {
+    const fieldData = {
+      type: 'text',
+      label: 'Username',
+      name: 'username-field',
+      instructions: 'Username must be between 2-30 characters',
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('input#username-field');
+
+    // Help text should not be visible initially
+    expect(container.textContent).not.toContain('Username must be between 2-30 characters');
+
+    // Focus the field
+    fireEvent.focus(input);
+
+    // Help text should now be visible
+    expect(container.textContent).toContain('Username must be between 2-30 characters');
+
+    // Blur the field
+    fireEvent.blur(input);
+
+    // Help text should be hidden again
+    expect(container.textContent).not.toContain('Username must be between 2-30 characters');
+  });
+
+  it('should show help text for textarea when focused', () => {
+    const fieldData = {
+      type: 'textarea',
+      label: 'Goals',
+      name: 'goals-field',
+      instructions: 'Please describe your learning goals in detail',
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('#goals-field');
+
+    // Help text should not be visible initially
+    expect(container.textContent).not.toContain('Please describe your learning goals in detail');
+
+    // Focus the field
+    fireEvent.focus(input);
+
+    // Help text should now be visible
+    expect(container.textContent).toContain('Please describe your learning goals in detail');
+  });
+
+  it('should not show help text if instructions are not provided', () => {
+    const fieldData = {
+      type: 'text',
+      label: 'Company',
+      name: 'company-field',
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('input#company-field');
+
+    // Focus the field
+    fireEvent.focus(input);
+
+    // No help text should be rendered since instructions are not provided
+    const feedbackElement = container.querySelector('.form-control-feedback');
+    expect(feedbackElement).toBeNull();
+  });
+
+  it('should show help text for select field when focused', () => {
+    const fieldData = {
+      type: 'select',
+      label: 'Country',
+      name: 'country-field',
+      options: [['us', 'United States'], ['ca', 'Canada']],
+      instructions: 'Select your country of residence',
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const select = container.querySelector('select#country-field');
+
+    // Help text should not be visible initially
+    expect(container.textContent).not.toContain('Select your country of residence');
+
+    // Focus the field
+    fireEvent.focus(select);
+
+    // Note: Select fields don't show help text in the current implementation
+    // This test documents the current behavior
+  });
 });

--- a/src/field-renderer/tests/FieldRenderer.test.jsx
+++ b/src/field-renderer/tests/FieldRenderer.test.jsx
@@ -45,7 +45,7 @@ describe('FieldRendererTests', () => {
       name: 'yob-field',
     };
 
-    const { container } = render(<FieldRenderer fieldData={fieldData} onChangeHandler={() => {}} />);
+    const { container } = render(<FieldRenderer fieldData={fieldData} onChangeHandler={() => { }} />);
     expect(container.innerHTML).toEqual('');
   });
 
@@ -105,7 +105,7 @@ describe('FieldRendererTests', () => {
       type: 'unknown',
     };
 
-    const { container } = render(<FieldRenderer fieldData={fieldData} onChangeHandler={() => {}} />);
+    const { container } = render(<FieldRenderer fieldData={fieldData} onChangeHandler={() => { }} />);
     expect(container.innerHTML).toContain('');
   });
 
@@ -347,8 +347,8 @@ describe('FieldRendererTests', () => {
     // Focus the field
     fireEvent.focus(select);
 
-    // Note: Select fields don't show help text in the current implementation
-    // This test documents the current behavior
+    // Help text should now be visible
+    expect(container.textContent).toContain('Select your country of residence');
   });
 
   it('should render select field with options as object format', () => {
@@ -400,14 +400,27 @@ describe('FieldRendererTests', () => {
       },
     };
 
-    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    let capturedValue = '';
+
+    const mockChangeHandler = jest.fn((event) => {
+      capturedValue = event.target.value;
+    });
+
+    const { container } = render(
+      <FieldRenderer value={value} fieldData={fieldData} onChangeHandler={mockChangeHandler} />,
+    );
+
     const select = container.querySelector('select#favorite-language-field');
 
     fireEvent.change(select, { target: { value: 'python' } });
-    expect(value).toEqual('python');
+
+    expect(mockChangeHandler).toHaveBeenCalled();
+    expect(capturedValue).toBe('python');
 
     fireEvent.change(select, { target: { value: 'javascript' } });
-    expect(value).toEqual('javascript');
+
+    expect(mockChangeHandler).toHaveBeenCalledTimes(2);
+    expect(capturedValue).toBe('javascript');
   });
 
   it('should render all options correctly from object format', () => {
@@ -478,7 +491,7 @@ describe('FieldRendererTests', () => {
       options: null,
     };
 
-    const { container } = render(<FieldRenderer fieldData={fieldData} onChangeHandler={() => {}} />);
+    const { container } = render(<FieldRenderer fieldData={fieldData} onChangeHandler={() => { }} />);
     expect(container.innerHTML).toEqual('');
   });
 });

--- a/src/field-renderer/tests/FieldRenderer.test.jsx
+++ b/src/field-renderer/tests/FieldRenderer.test.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { getConfig } from '@edx/frontend-platform';
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 
 import FieldRenderer from '../FieldRenderer';
 
@@ -261,7 +261,7 @@ describe('FieldRendererTests', () => {
     expect(input.maxLength).toEqual(200);
   });
 
-  it('should show help text when field has focus and instructions are provided', () => {
+  it('should show help text when field has focus and instructions are provided', async () => {
     const fieldData = {
       type: 'text',
       label: 'Username',
@@ -284,8 +284,10 @@ describe('FieldRendererTests', () => {
     // Blur the field
     fireEvent.blur(input);
 
-    // Help text should be hidden again
-    expect(container.textContent).not.toContain('Username must be between 2-30 characters');
+    // Help text should be hidden again (wait for animation to complete)
+    await waitFor(() => {
+      expect(container.textContent).not.toContain('Username must be between 2-30 characters');
+    });
   });
 
   it('should show help text for textarea when focused', () => {

--- a/src/field-renderer/tests/FieldRenderer.test.jsx
+++ b/src/field-renderer/tests/FieldRenderer.test.jsx
@@ -261,6 +261,74 @@ describe('FieldRendererTests', () => {
     expect(input.maxLength).toEqual(200);
   });
 
+  it('should apply minLength restriction to text field', () => {
+    const fieldData = {
+      type: 'text',
+      label: 'Username',
+      name: 'username-field',
+      restrictions: {
+        min_length: 3,
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('input#username-field');
+
+    expect(input.minLength).toEqual(3);
+  });
+
+  it('should apply minLength restriction to textarea field', () => {
+    const fieldData = {
+      type: 'textarea',
+      label: 'Goals',
+      name: 'goals-field',
+      restrictions: {
+        min_length: 10,
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('#goals-field');
+
+    expect(input.minLength).toEqual(10);
+  });
+
+  it('should apply both minLength and maxLength restrictions to text field', () => {
+    const fieldData = {
+      type: 'text',
+      label: 'Username',
+      name: 'username-field',
+      restrictions: {
+        min_length: 3,
+        max_length: 30,
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('input#username-field');
+
+    expect(input.minLength).toEqual(3);
+    expect(input.maxLength).toEqual(30);
+  });
+
+  it('should apply both minLength and maxLength restrictions to textarea field', () => {
+    const fieldData = {
+      type: 'textarea',
+      label: 'Goals',
+      name: 'goals-field',
+      restrictions: {
+        min_length: 10,
+        max_length: 200,
+      },
+    };
+
+    const { container } = render(<FieldRenderer value={value} fieldData={fieldData} onChangeHandler={changeHandler} />);
+    const input = container.querySelector('#goals-field');
+
+    expect(input.minLength).toEqual(10);
+    expect(input.maxLength).toEqual(200);
+  });
+
   it('should show help text when field has focus and instructions are provided', async () => {
     const fieldData = {
       type: 'text',

--- a/src/register/components/ConfigurableRegistrationForm.jsx
+++ b/src/register/components/ConfigurableRegistrationForm.jsx
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import { FormFieldRenderer } from '../../field-renderer';
 import { FIELDS } from '../data/constants';
 import messages from '../messages';
+import { normalizeErrorMessage } from '../data/utils';
 import { CountryField, HonorCode, TermsOfService } from '../RegistrationFields';
 
 /**
@@ -97,7 +98,7 @@ const ConfigurableRegistrationForm = (props) => {
     const { name, value } = event.target;
     let error = '';
     if ((!value || !value.trim()) && fieldDescriptions[name]?.error_message) {
-      error = fieldDescriptions[name].error_message;
+      error = normalizeErrorMessage(fieldDescriptions[name].error_message);
     } else if (name === 'confirm_email' && value !== email) {
       error = formatMessage(messages['email.do.not.match']);
     }

--- a/src/register/components/ConfigurableRegistrationForm.jsx
+++ b/src/register/components/ConfigurableRegistrationForm.jsx
@@ -6,8 +6,8 @@ import PropTypes from 'prop-types';
 
 import { FormFieldRenderer } from '../../field-renderer';
 import { FIELDS } from '../data/constants';
-import messages from '../messages';
 import { normalizeErrorMessage } from '../data/utils';
+import messages from '../messages';
 import { CountryField, HonorCode, TermsOfService } from '../RegistrationFields';
 
 /**

--- a/src/register/components/tests/ConfigurableRegistrationForm.test.jsx
+++ b/src/register/components/tests/ConfigurableRegistrationForm.test.jsx
@@ -419,5 +419,36 @@ describe('ConfigurableRegistrationForm', () => {
 
       expect(professionErrorElement.textContent).toEqual(professionError);
     });
+
+    it('should normalize object-style error messages from backend', () => {
+      const professionErrorMessage = { required: 'Enter your profession' };
+
+      store = mockStore({
+        ...initialState,
+        commonComponents: {
+          ...initialState.commonComponents,
+          fieldDescriptions: {
+            profession: {
+              name: 'profession', type: 'text', label: 'Profession', error_message: professionErrorMessage,
+            },
+          },
+        },
+      });
+
+      const { getByLabelText, container } = render(
+        routerWrapper(reduxWrapper(<IntlRegistrationPage {...props} />)),
+      );
+
+      const professionInput = getByLabelText('Profession');
+      fireEvent.focus(professionInput);
+      fireEvent.blur(professionInput);
+
+      const submitButton = container.querySelector('button.btn-brand');
+      fireEvent.click(submitButton);
+
+      const professionErrorElement = container.querySelector('#profession-error');
+
+      expect(professionErrorElement.textContent).toEqual('Enter your profession');
+    });
   });
 });

--- a/src/register/data/tests/utils.test.js
+++ b/src/register/data/tests/utils.test.js
@@ -1,4 +1,38 @@
-import { isFormValid } from '../utils';
+import { isFormValid, normalizeErrorMessage } from '../utils';
+
+describe('normalizeErrorMessage', () => {
+  it('should return the error message if it is a string', () => {
+    const errorMessage = 'This field is required';
+    expect(normalizeErrorMessage(errorMessage)).toBe('This field is required');
+  });
+
+  it('should extract the first value from an object error message', () => {
+    const errorMessage = { required: 'This field is required' };
+    expect(normalizeErrorMessage(errorMessage)).toBe('This field is required');
+  });
+
+  it('should handle multiple keys in object and return first value', () => {
+    const errorMessage = { required: 'Required field', min_length: 'Too short' };
+    const result = normalizeErrorMessage(errorMessage);
+    expect(['Required field', 'Too short']).toContain(result);
+  });
+
+  it('should return empty string if error message is null', () => {
+    expect(normalizeErrorMessage(null)).toBe('');
+  });
+
+  it('should return empty string if error message is undefined', () => {
+    expect(normalizeErrorMessage(undefined)).toBe('');
+  });
+
+  it('should return empty string if error message is an empty object', () => {
+    expect(normalizeErrorMessage({})).toBe('');
+  });
+
+  it('should return empty string if error message is an empty string', () => {
+    expect(normalizeErrorMessage('')).toBe('');
+  });
+});
 
 describe('Payload validation', () => {
   let formatMessage;

--- a/src/register/data/utils.js
+++ b/src/register/data/utils.js
@@ -7,6 +7,19 @@ import validateName from '../RegistrationFields/NameField/validator';
 import validateUsername from '../RegistrationFields/UsernameField/validator';
 
 /**
+ * Normalizes a field error_message that may come from the backend as either
+ * a plain string or an object (e.g. { required: "Error text" }).
+ * @param {string|object} errorMessage
+ * @returns {string}
+ */
+export const normalizeErrorMessage = (errorMessage) => {
+  if (typeof errorMessage === 'object' && errorMessage !== null) {
+    return Object.values(errorMessage)[0] || '';
+  }
+  return errorMessage || '';
+};
+
+/**
  * It validates the password field value
  * @param value
  * @param formatMessage
@@ -96,7 +109,7 @@ export const isFormValid = (
     if (key === 'country' && !configurableFormFields?.country?.displayValue) {
       fieldErrors[key] = formatMessage(messages['empty.country.field.error']);
     } else if (!configurableFormFields[key]) {
-      fieldErrors[key] = fieldDescriptions[key].error_message;
+      fieldErrors[key] = normalizeErrorMessage(fieldDescriptions[key].error_message);
     }
     if (fieldErrors[key]) { isValid = false; }
   });


### PR DESCRIPTION
Closes: https://github.com/eduNEXT/consulting-issues-mapping/issues/829

### Description

This PR improves the `FormFieldRenderer` component and the configurable registration form with better UX feedback, input validation, and more robust error message handling.

1. Placeholder support for `text` and `textarea` fields in `FormFieldRenderer`.
2. `maxLength` restriction applied natively on text inputs using `fieldData.restrictions.max_length`.
3. Animated help text on focus, displays `fieldData.instructions` while the field is focused, using `TransitionReplace`.
4. Error message normalization, new `normalizeErrorMessage` utility that converts backend error messages arriving as objects (e.g., `{ required: "..." }`) to strings, preventing `[object Object]` from being displayed.

### Related Issues

- Upstream PR: https://github.com/openedx/frontend-app-authn/pull/1669/

### Testing Instructions

Using Tutor:
1. Use changes in this PR: https://github.com/eduNEXT-collab/campus-agora-your-cluster-project/pull/8
2. Create a mount of the MFE, cloning this repository in your tutor root environment, and run `tutor mounts add frontend-app-authn`
3. Run `nvm use && npm install`
4. Go to the registration page at http://apps.local.openedx.io:1999/authn/register
5. You should see a new field called `Date of birth`.
6. You can test the new validations, user feedback, and error messages.

### Screenshots/sandbox (optional):

| Before | After |
|--------|--------|
| **Without placeholder and help text** <img width="665" height="240" alt="image" src="https://github.com/user-attachments/assets/9ada0e64-bbb9-430c-98f1-c3da160f1322" /> | **With placeholder and help text** <img width="665" height="240" alt="image" src="https://github.com/user-attachments/assets/e2930b9e-51d1-47f0-a193-364cc0c16773" /> |
| ERROR! ❌ | **Field required message** <img width="665" height="141" alt="image" src="https://github.com/user-attachments/assets/479ed0e5-1da3-4646-9266-cc40a77178c8" /> |
| **Without max length restriction** <img width="620" height="125" alt="image" src="https://github.com/user-attachments/assets/5c8becac-d639-46e8-a5ea-f652e89d91d6" /> | **With max length restriction** <img width="665" height="115" alt="image" src="https://github.com/user-attachments/assets/646fb5ed-9247-4824-8b94-9a6ef304c006" /> |